### PR TITLE
Add TLS, Prometheus & Grafana monitoring, Alertmanager integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 backend/certs/
 frontend/admin/certs/
 frontend/pong/certs/
+devops/monitoring/grafana/certs/
+devops/monitoring/prometheus/certs/
 *.pem
+*.key
+*.crt
 
 # логи
 *.log

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
-HOSTS := localhost 127.0.0.1 ::1
+HOSTS := localhost 127.0.0.1 ::1 backend frontend-admin frontend-pong grafana prometheus
 
 # Папки, куда будем писать pem-файлы
 BACKEND_CERT_DIR := backend/certs
 ADMIN_CERT_DIR   := frontend/admin/certs
 PONG_CERT_DIR    := frontend/pong/certs
+GRAFANA_CERT_DIR := devops/monitoring/grafana/certs
+PROMETHEUS_CERT_DIR := devops/monitoring/prometheus/certs
 
 .PHONY: all certs up
 
@@ -13,13 +15,16 @@ certs:
 	@echo "→ Generating mkcert root CA (idempotent)…"
 	@mkcert -install
 	@echo "→ Ensuring cert dirs exist…"
-	@mkdir -p $(BACKEND_CERT_DIR) $(ADMIN_CERT_DIR) $(PONG_CERT_DIR)
+	@mkdir -p $(BACKEND_CERT_DIR) $(ADMIN_CERT_DIR) $(PONG_CERT_DIR) $(GRAFANA_CERT_DIR) $(PROMETHEUS_CERT_DIR)
 	@echo "→ Generating backend cert…"
-	@mkcert -key-file $(BACKEND_CERT_DIR)/key.pem   -cert-file $(BACKEND_CERT_DIR)/cert.pem   $(HOSTS)
+	@mkcert -key-file $(BACKEND_CERT_DIR)/key.pem   		-cert-file $(BACKEND_CERT_DIR)/cert.pem   		 $(HOSTS)
 	@echo "→ Generating admin cert…"
-	@mkcert -key-file $(ADMIN_CERT_DIR)/key.pem     -cert-file $(ADMIN_CERT_DIR)/cert.pem     $(HOSTS)
+	@mkcert -key-file $(ADMIN_CERT_DIR)/key.pem     		-cert-file $(ADMIN_CERT_DIR)/cert.pem     		 $(HOSTS)
 	@echo "→ Generating pong cert…"
-	@mkcert -key-file $(PONG_CERT_DIR)/key.pem      -cert-file $(PONG_CERT_DIR)/cert.pem      $(HOSTS)
-
+	@mkcert -key-file $(PONG_CERT_DIR)/key.pem      		-cert-file $(PONG_CERT_DIR)/cert.pem      		 $(HOSTS)
+	@echo "→ Generating grafana cert…"
+	@mkcert -key-file $(GRAFANA_CERT_DIR)/grafana.key 		-cert-file $(GRAFANA_CERT_DIR)/grafana.crt 		 $(HOSTS)
+	@echo "→ Generating prometheus cert…"
+	@mkcert -key-file $(PROMETHEUS_CERT_DIR)/prometheus.key -cert-file $(PROMETHEUS_CERT_DIR)/prometheus.crt $(HOSTS)
 up:
 	docker-compose up --build

--- a/devops/monitoring/alertmanager/config.tpl.yml
+++ b/devops/monitoring/alertmanager/config.tpl.yml
@@ -13,6 +13,7 @@ receivers:
     telegram_configs:
       - bot_token: ${TELEGRAM_BOT_TOKEN}
         chat_id: 1382792490
+        #send_resolved: false
         parse_mode: ''
         message: |
           🚨 {{ .Status | toUpper }} ALERT: {{ .CommonLabels.alertname }}

--- a/devops/monitoring/grafana/Dockerfile
+++ b/devops/monitoring/grafana/Dockerfile
@@ -2,7 +2,8 @@ FROM grafana/grafana:10.2.3
 
 COPY provisioning/ /etc/grafana/provisioning/
 
-# COPY grafana.ini /etc/grafana/grafana.ini
+COPY grafana.ini /etc/grafana/grafana.ini
+COPY certs/ /etc/grafana/certs/
 
 # COPY grafana.db /var/lib/grafana/grafana.db
 

--- a/devops/monitoring/grafana/grafana.ini
+++ b/devops/monitoring/grafana/grafana.ini
@@ -1,0 +1,5 @@
+[server]
+protocol = https
+http_port = 3000
+cert_file = /etc/grafana/certs/grafana.crt
+cert_key = /etc/grafana/certs/grafana.key

--- a/devops/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/devops/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -4,5 +4,7 @@ datasources:
   - name: Prometheus
     type: prometheus
     access: proxy
-    url: http://prometheus:9090
+    url: https://prometheus:9090
     isDefault: true
+    jsonData:
+      tlsSkipVerify: true

--- a/devops/monitoring/prometheus/Dockerfile
+++ b/devops/monitoring/prometheus/Dockerfile
@@ -2,13 +2,18 @@ FROM prom/prometheus:v2.53.0
 
 WORKDIR /etc/prometheus
 
+#COPY configs/ /etc/prometheus/
 COPY configs/prometheus.yml .
 COPY configs/prometheus_rules.yml .
+COPY configs/web.yml . 
+COPY certs/ /etc/prometheus/certs/
 
 EXPOSE 9090
 
 RUN /bin/promtool check rules /etc/prometheus/prometheus_rules.yml
 
-CMD ["--config.file=/etc/prometheus/prometheus.yml", "--web.listen-address=:9090"]
+#CMD ["--config.file=/etc/prometheus/prometheus.yml", "--web.listen-address=:9090"]
+CMD ["--config.file=/etc/prometheus/prometheus.yml", "--web.listen-address=:9090", "--web.config.file=/etc/prometheus/web.yml"]
+
 # "--storage.tsdb.path=/prometheus"
 # если потребуется кастовать путь вместо prometheus-data:/var/lib/prometheus

--- a/devops/monitoring/prometheus/configs/prometheus.yml
+++ b/devops/monitoring/prometheus/configs/prometheus.yml
@@ -6,9 +6,33 @@ rule_files:
   - "prometheus_rules.yml"
 
 scrape_configs:
+# - job_name: 'backend'
+#   scheme: https
+#   tls_config:
+#     insecure_skip_verify: true
+#   static_configs:
+#     - targets: ['backend:3000']
+
+# - job_name: 'frontend-admin'
+#   scheme: https
+#   tls_config:
+#     insecure_skip_verify: true
+#   static_configs:
+#     - targets: ['frontend-admin:443']
+
+# - job_name: 'frontend-pong'
+#   scheme: https
+#   tls_config:
+#     insecure_skip_verify: true
+#   static_configs:
+#     - targets: ['frontend-pong:443']
+
   - job_name: 'prometheus'
+    scheme: https
+    tls_config:
+      insecure_skip_verify: true
     static_configs:
-      - targets: ['localhost:9090']
+    - targets: ['localhost:9090']
 
   - job_name: 'node_exporter'
     static_configs:
@@ -19,6 +43,9 @@ scrape_configs:
       - targets: ['cadvisor:8080']
         
   - job_name: 'grafana'
+    scheme: https
+    tls_config:
+      insecure_skip_verify: true
     static_configs:
       - targets: ['grafana:3000']
 

--- a/devops/monitoring/prometheus/configs/prometheus_rules.yml
+++ b/devops/monitoring/prometheus/configs/prometheus_rules.yml
@@ -21,13 +21,22 @@ groups:
           description: "Контейнер {{ $labels.name }} с image {{ $labels.image }} использует более 80% CPU"
 
       - alert: ContainerDown
-        expr: up{job=~"cadvisor|node_exporter|grafana|nginx"} == 0
+        expr: up{job=~"cadvisor|node_exporter|grafana|backend|frontend-admin|frontend-pong"} == 0
         for: 1m
         labels:
           severity: critical
         annotations:
           summary: "Контейнер пропал"
           description: "Контейнер {{ $labels.job }} недоступен по адресу {{ $labels.instance }}"
+      
+      - alert: ContainerMissing
+        expr: time() - container_last_seen{name=~"frontend-admin|frontend-pong|trance_and_dance_backend_1"} > 60
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Контейнер пропал"
+          description: "Контейнер {{ $labels.name }} ({{ $labels.instance }}) не отвечает более 1 минуты"
 
       - alert: TestFakeDown
         expr: vector(1)

--- a/devops/monitoring/prometheus/configs/web.yml
+++ b/devops/monitoring/prometheus/configs/web.yml
@@ -1,0 +1,3 @@
+tls_server_config:
+  cert_file: /etc/prometheus/certs/prometheus.crt
+  key_file: /etc/prometheus/certs/prometheus.key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - ./backend/certs:/app/certs
     ports:
       - "3000:3000"
+    networks:
+      - monitoring-tier
 
   admin-frontend:
     build:
@@ -27,6 +29,8 @@ services:
       - backend
     environment:
       - API_URL=http://backend:3000
+    networks:
+      - monitoring-tier
 
   pong-frontend:
     build:
@@ -41,6 +45,8 @@ services:
       - backend
     environment:
       - API_URL=http://backend:3000
+    networks:
+      - monitoring-tier
 
   prometheus:
     container_name: prometheus
@@ -66,7 +72,8 @@ services:
       - GF_USERS_DEFAULT_THEME=light
       - GF_AUTH_ANONYMOUS_ENABLED=false
       - GF_METRICS_ENABLED=true
-      - GF_METRICS_ENDPOINT=/metrics  
+      - GF_METRICS_ENDPOINT=/metrics
+      - GF_SECURITY_SKIP_VERIFY=true 
     volumes:
       - grafana-data:/var/lib/grafana
     ports:
@@ -78,8 +85,10 @@ services:
   node-exporter:
     container_name: node-exporter
     image: quay.io/prometheus/node-exporter:v1.8.2
-    ports:
-      - "9203:9100"
+    #ports:
+    #  - "9203:9100"
+    expose:
+      - "9093"
     volumes:
       - /:/host:ro
     command:
@@ -91,8 +100,10 @@ services:
   cadvisor:
     container_name: cadvisor
     image: gcr.io/cadvisor/cadvisor:v0.47.2
-    ports:
-      - "9204:8080"
+    #ports:
+    #  - "9204:8080"
+    expose:
+      - "8080"
     volumes:
       - /var/run:/var/run:ro
       - /sys:/sys:ro
@@ -106,8 +117,10 @@ services:
     build:
       context: ./devops/monitoring/alertmanager
       dockerfile: Dockerfile
-    ports:
-      - '9202:9093'
+    #ports:
+    #  - '9202:9093'
+    expose:
+      - "9093"
     env_file:
       - .env
     networks:


### PR DESCRIPTION
🔧 Что сделано:
- Настроен TLS для Grafana и Prometheus (через встроенные возможности)
- Добавлена генерация сертификатов в Makefile
- Включён HTTPS-сбор метрик с Grafana
- Конфигурирован Prometheus для HTTPS + web.yml
- Настроен Alertmanager (включая Telegram алерты)
- Добавлены алерты:
  - падение контейнеров (через cadvisor + контейнерные имена)
  - высокая загрузка CPU хоста и контейнеров
- Удалены прямые `scrape_configs` для backend/frontend из-за ошибок парсинга

🧪 Проверено:
- Контейнеры запускаются без ошибок
- Алерты приходят корректно
- Сертификаты валидны