### PR TITLE
fix(devops): chmod 644 для ключей mkcert и стабильная сборка

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,13 @@ certs:
 	@mkcert -key-file $(PONG_CERT_DIR)/key.pem      		-cert-file $(PONG_CERT_DIR)/cert.pem      		 $(HOSTS)
 	@echo "→ Generating grafana cert…"
 	@mkcert -key-file $(GRAFANA_CERT_DIR)/grafana.key 		-cert-file $(GRAFANA_CERT_DIR)/grafana.crt 		 $(HOSTS)
+	@chmod 644 $(GRAFANA_CERT_DIR)/*.key || true
 	@echo "→ Generating prometheus cert…"
 	@mkcert -key-file $(PROMETHEUS_CERT_DIR)/prometheus.key -cert-file $(PROMETHEUS_CERT_DIR)/prometheus.crt $(HOSTS)
+	@chmod 644 $(PROMETHEUS_CERT_DIR)/*.key || true
 up:
 	docker-compose -f docker-compose.yml -f docker-compose.elk.yml up --build
+down:
+	docker-compose -f docker-compose.yml -f docker-compose.elk.yml down
+down-volumes:
+	docker-compose -f docker-compose.yml -f docker-compose.elk.yml down -v

--- a/devops/monitoring/grafana/Dockerfile
+++ b/devops/monitoring/grafana/Dockerfile
@@ -8,5 +8,3 @@ COPY certs/ /etc/grafana/certs/
 # COPY grafana.db /var/lib/grafana/grafana.db
 
 EXPOSE 3000
-
-


### PR DESCRIPTION
### Summary
Added `down` and `down-volumes` targets to the Makefile for better container cleanup.
Also added `chmod 644`

### Changes
- `make down`: stops and removes containers
- `make down-volumes`: stops and removes containers + volumes
